### PR TITLE
feat: 운동 기록(Record) API 구현

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,18 +2,21 @@ import express from 'express';
 import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { errorHandler, notFoundHandler } from './middlewares/error-handler.js';
-import imageRoutes from './routes/image-routes.js';
-import healthRoutes from './routes/health-routes.js';
-import participantRoutes from './routes/participant-routes.js';
-import groupLikeCount from './routes/group-like-count-routes.js';
 import { debugLog } from './utils/debug.js';
+
+// ============================================
+// 미들웨어 import
+// ============================================
 import { errorHandler, notFoundHandler } from './middlewares/error-handler.js';
 
+// ============================================
 // 라우터 import
+// ============================================
 import healthRoutes from './routes/health-routes.js';
-import recordRoutes from './routes/record-routes.js';
 import imageRoutes from './routes/image-routes.js';
+import participantRoutes from './routes/participant-routes.js';
+import groupLikeCount from './routes/group-like-count-routes.js';
+import recordRoutes from './routes/record-routes.js';
 
 // ============================================
 // 환경 변수 설정
@@ -48,21 +51,22 @@ app.use('/uploads', express.static(path.join(__dirname, '../public/uploads')));
 
 // ============================================
 // 라우터 등록
+// ============================================
+
+// 헬스 체크
 app.use('/health', healthRoutes);
 
 // ============================================
 // TODO: 개발하신 라우터들을 이곳에서 구현 및 적용하시면 됩니다.
 // ============================================
 
-// 1. 이미지 업로드
+// 1. 이미지 업로드 API
 app.use('/images', imageRoutes);
 
-// 3. 그룹 관련 라우터들
+// 2. 그룹 관련 라우터들
 app.use('/groups', participantRoutes); // /groups/:groupId/participants
 app.use('/groups', groupLikeCount); // /groups/:groupId/like
-
-// 이미지 업로드 API
-app.use('/images', imageRoutes);
+app.use('/groups/:groupId/records', recordRoutes); // /groups/:groupId/records
 
 // ============================================
 // 404 핸들러

--- a/src/app.js
+++ b/src/app.js
@@ -1,35 +1,52 @@
-import express from "express";
-import cors from "cors";
-import dotenv from "dotenv";
-import path from "path";
-import { fileURLToPath } from "url";
-import { errorHandler, notFoundHandler } from "./middlewares/error-handler.js";
+import express from 'express';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { errorHandler, notFoundHandler } from './middlewares/error-handler.js';
 import imageRoutes from './routes/image-routes.js';
-import healthRoutes from "./routes/health-routes.js";
+import healthRoutes from './routes/health-routes.js';
 import participantRoutes from './routes/participant-routes.js';
-import groupLikeCount from "./routes/group-like-count-routes.js";
-import { debugLog } from "./utils/debug.js";
+import groupLikeCount from './routes/group-like-count-routes.js';
+import { debugLog } from './utils/debug.js';
+import { errorHandler, notFoundHandler } from './middlewares/error-handler.js';
 
-// ES 모듈에서 __dirname 사용하기
+// 라우터 import
+import healthRoutes from './routes/health-routes.js';
+import recordRoutes from './routes/record-routes.js';
+import imageRoutes from './routes/image-routes.js';
+
+// ============================================
+// 환경 변수 설정
+// ============================================
+dotenv.config();
+
+const PORT = process.env.PORT || 3001;
+
+// ============================================
+// ES Module에서 __dirname 사용하기
+// ============================================
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// 환경 변수 로드
-dotenv.config();
-
+// ============================================
+// Express 앱 생성
+// ============================================
 const app = express();
-const PORT = process.env.PORT || 3000;
 
-// CORS 설정
-app.use(cors());
+// ============================================
+// 미들웨어 설정
+// ============================================
 
 // JSON 파싱
 app.use(express.json());
+
+// URL-encoded 파싱
 app.use(express.urlencoded({ extended: true }));
 
 // 정적 파일 제공 (업로드된 이미지)
 app.use('/uploads', express.static(path.join(__dirname, '../public/uploads')));
 
+// ============================================
 // 라우터 등록
 app.use('/health', healthRoutes);
 
@@ -40,17 +57,26 @@ app.use('/health', healthRoutes);
 // 1. 이미지 업로드
 app.use('/images', imageRoutes);
 
-// 3. 그룹 관련 라우터들 
-app.use('/groups', participantRoutes);    // /groups/:groupId/participants
-app.use("/groups", groupLikeCount);       // /groups/:groupId/like
+// 3. 그룹 관련 라우터들
+app.use('/groups', participantRoutes); // /groups/:groupId/participants
+app.use('/groups', groupLikeCount); // /groups/:groupId/like
 
+// 이미지 업로드 API
+app.use('/images', imageRoutes);
+
+// ============================================
 // 404 핸들러
+// ============================================
 app.use(notFoundHandler);
 
+// ============================================
 // Global Error Handler
+// ============================================
 app.use(errorHandler);
 
+// ============================================
 // 서버 시작
+// ============================================
 app.listen(PORT, () => {
   console.log(`🚀 Team1 SEVEN API Server is running on port ${PORT}`);
   debugLog('Debug mode is enabled');

--- a/src/controllers/record-controller.js
+++ b/src/controllers/record-controller.js
@@ -1,15 +1,21 @@
-import prisma from "../utils/prisma.js";
-import { debugLog, debugError } from "../utils/debug.js";
+import prisma from '../utils/prisma.js';
+import { debugLog } from '../utils/debug.js';
+import { NotFoundError, UnauthorizedError } from '../middlewares/error-handler.js';
 import {
-  NotFoundError,
-  UnauthorizedError,
-} from "../middlewares/error-handler.js";
+  convertUrlsToPaths,
+  convertImageFieldsToUrls,
+  convertArrayImageFieldsToUrls,
+} from '../utils/image-utils.js';
 
+/**
+ * 운동 기록 컨트롤러
+ * 그룹의 운동 기록 생성, 조회, 목록 조회 기능 제공
+ */
 class RecordController {
   // ============================================
   // POST /groups/:groupId/records - 운동 기록 생성
   // ============================================
-  async createRecord(req, res) {
+  async createRecord(req, res, next) {
     const groupId = parseInt(req.params.groupId);
     const {
       exerciseType,
@@ -21,10 +27,11 @@ class RecordController {
       authorPassword,
     } = req.body;
 
-    debugLog("운동 기록 생성 요청:", {
+    debugLog('운동 기록 생성 요청:', {
       groupId,
       exerciseType,
       authorNickname,
+      photos, // 클라이언트가 보낸 photos (URL 배열)
     });
 
     try {
@@ -38,18 +45,31 @@ class RecordController {
         },
       });
 
-      if (!author || author.password !== authorPassword) {
-        throw new UnauthorizedError("닉네임 또는 비밀번호가 일치하지 않습니다");
+      // 참여자가 없으면 닉네임 에러
+      if (!author) {
+        throw new UnauthorizedError('authorNickname', '닉네임을 찾을 수 없습니다');
       }
 
-      // 2. 기록 생성
+      // 비밀번호가 일치하지 않으면 비밀번호 에러
+      if (author.password !== authorPassword) {
+        throw new UnauthorizedError('authorPassword', '비밀번호가 일치하지 않습니다');
+      }
+
+      // 2. photos URL에서 경로 추출 (공통 유틸리티 사용)
+      // 클라이언트가 보낸 ["http://localhost:3000/uploads/abc.jpg"]
+      // → DB에 저장할 ["uploads/abc.jpg"]
+      const photoPaths = convertUrlsToPaths(photos);
+
+      debugLog('추출된 경로:', photoPaths);
+
+      // 3. 기록 생성 (경로만 저장)
       const record = await prisma.record.create({
         data: {
           exerciseType,
           description,
           time,
           distance,
-          photos,
+          photos: photoPaths, // ["uploads/abc.jpg"] 저장
           groupId,
           authorId: author.id,
         },
@@ -63,41 +83,48 @@ class RecordController {
         },
       });
 
-      debugLog("운동 기록 생성 완료:", record.id);
+      debugLog('운동 기록 생성 완료:', record.id);
+      debugLog('DB에 저장된 photos:', record.photos);
 
-      // 3. 디스코드 웹훅 전송 (비동기, 실패해도 무시)
+      // 4. 디스코드 웹훅 전송 (비동기, 실패해도 무시)
       const group = await prisma.group.findUnique({
         where: { id: groupId },
       });
 
       if (group?.discordWebhookUrl) {
         // TODO: 디스코드 웹훅 전송 로직 구현 (추후 구현)
-        debugLog("디스코드 웹훅 URL:", group.discordWebhookUrl);
+        debugLog('디스코드 웹훅 URL:', group.discordWebhookUrl);
       }
 
-      // 4. 배지 업데이트 (추후 구현)
+      // 5. 배지 업데이트 (추후 구현)
       // await updateGroupBadges(groupId);
 
+      // 6. 응답: 경로를 다시 전체 URL로 변환 (공통 유틸리티 사용)
+      // ["uploads/abc.jpg"] → ["http://localhost:3000/uploads/abc.jpg"]
+      const recordWithUrls = convertImageFieldsToUrls(record, ['photos']);
+
+      debugLog('응답 photos:', recordWithUrls.photos);
+
       // API 명세에 맞는 응답 형식
-      res.status(201).json(record);
+      res.status(201).json(recordWithUrls);
     } catch (error) {
-      debugError("운동 기록 생성 실패:", error);
-      throw error;
+      // Global Error Handler로 전달
+      next(error);
     }
   }
 
   // ============================================
   // GET /groups/:groupId/records - 운동 기록 목록 조회
   // ============================================
-  async getRecords(req, res) {
+  async getRecords(req, res, next) {
     const groupId = parseInt(req.params.groupId);
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 10;
-    const order = req.query.order || "desc";
-    const orderBy = req.query.orderBy || "createdAt";
-    const search = req.query.search || "";
+    const order = req.query.order || 'desc';
+    const orderBy = req.query.orderBy || 'createdAt';
+    const search = req.query.search || '';
 
-    debugLog("운동 기록 목록 조회:", { groupId, page, limit, order, orderBy });
+    debugLog('운동 기록 목록 조회:', { groupId, page, limit, order, orderBy });
 
     try {
       // WHERE 조건
@@ -107,7 +134,7 @@ class RecordController {
           author: {
             nickname: {
               contains: search,
-              mode: "insensitive",
+              mode: 'insensitive',
             },
           },
         }),
@@ -137,9 +164,13 @@ class RecordController {
 
       debugLog(`운동 기록 ${records.length}개 조회 완료 (전체: ${total})`);
 
+      // 각 record의 photos를 URL로 변환 (공통 유틸 image-utils 사용)
+      // DB: ["uploads/abc.jpg"] → 응답: ["http://localhost:3000/uploads/abc.jpg"]
+      const recordsWithUrls = convertArrayImageFieldsToUrls(records, ['photos']);
+
       res.status(200).json({
-        message: "운동 기록 목록 조회 성공",
-        data: records,
+        message: '운동 기록 목록 조회 성공',
+        data: recordsWithUrls,
         pagination: {
           page,
           limit,
@@ -148,19 +179,19 @@ class RecordController {
         },
       });
     } catch (error) {
-      debugError("운동 기록 목록 조회 실패:", error);
-      throw error;
+      // Global Error Handler로 전달
+      next(error);
     }
   }
 
   // ============================================
   // GET /groups/:groupId/records/:recordId - 운동 기록 상세 조회
   // ============================================
-  async getRecordById(req, res) {
+  async getRecordById(req, res, next) {
     const groupId = parseInt(req.params.groupId);
     const recordId = parseInt(req.params.recordId);
 
-    debugLog("운동 기록 상세 조회:", { groupId, recordId });
+    debugLog('운동 기록 상세 조회:', { groupId, recordId });
 
     try {
       const record = await prisma.record.findFirst({
@@ -179,16 +210,23 @@ class RecordController {
       });
 
       if (!record) {
-        throw new NotFoundError("운동 기록을 찾을 수 없습니다");
+        throw new NotFoundError('운동 기록을 찾을 수 없습니다');
       }
 
-      debugLog("운동 기록 상세 조회 완료:", record.id);
+      debugLog('운동 기록 상세 조회 완료:', record.id);
+      debugLog('DB의 photos:', record.photos);
+
+      // photos를 URL로 변환 (공통 유틸 image-utils 사용)
+      // DB: ["uploads/abc.jpg"] → 응답: ["http://localhost:3000/uploads/abc.jpg"]
+      const recordWithUrls = convertImageFieldsToUrls(record, ['photos']);
+
+      debugLog('응답 photos:', recordWithUrls.photos);
 
       // API 명세에 맞는 응답 형식
-      res.status(200).json(record);
+      res.status(200).json(recordWithUrls);
     } catch (error) {
-      debugError("운동 기록 상세 조회 실패:", error);
-      throw error;
+      // Global Error Handler로 전달
+      next(error);
     }
   }
 }

--- a/src/controllers/record-controller.js
+++ b/src/controllers/record-controller.js
@@ -1,0 +1,196 @@
+import prisma from "../utils/prisma.js";
+import { debugLog, debugError } from "../utils/debug.js";
+import {
+  NotFoundError,
+  UnauthorizedError,
+} from "../middlewares/error-handler.js";
+
+class RecordController {
+  // ============================================
+  // POST /groups/:groupId/records - 운동 기록 생성
+  // ============================================
+  async createRecord(req, res) {
+    const groupId = parseInt(req.params.groupId);
+    const {
+      exerciseType,
+      description,
+      time,
+      distance,
+      photos = [],
+      authorNickname,
+      authorPassword,
+    } = req.body;
+
+    debugLog("운동 기록 생성 요청:", {
+      groupId,
+      exerciseType,
+      authorNickname,
+    });
+
+    try {
+      // 1. 참여자 확인 및 검증
+      const author = await prisma.participant.findUnique({
+        where: {
+          unique_nickname_per_group: {
+            groupId,
+            nickname: authorNickname,
+          },
+        },
+      });
+
+      if (!author || author.password !== authorPassword) {
+        throw new UnauthorizedError("닉네임 또는 비밀번호가 일치하지 않습니다");
+      }
+
+      // 2. 기록 생성
+      const record = await prisma.record.create({
+        data: {
+          exerciseType,
+          description,
+          time,
+          distance,
+          photos,
+          groupId,
+          authorId: author.id,
+        },
+        include: {
+          author: {
+            select: {
+              id: true,
+              nickname: true,
+            },
+          },
+        },
+      });
+
+      debugLog("운동 기록 생성 완료:", record.id);
+
+      // 3. 디스코드 웹훅 전송 (비동기, 실패해도 무시)
+      const group = await prisma.group.findUnique({
+        where: { id: groupId },
+      });
+
+      if (group?.discordWebhookUrl) {
+        // TODO: 디스코드 웹훅 전송 로직 구현 (추후 구현)
+        debugLog("디스코드 웹훅 URL:", group.discordWebhookUrl);
+      }
+
+      // 4. 배지 업데이트 (추후 구현)
+      // await updateGroupBadges(groupId);
+
+      // API 명세에 맞는 응답 형식
+      res.status(201).json(record);
+    } catch (error) {
+      debugError("운동 기록 생성 실패:", error);
+      throw error;
+    }
+  }
+
+  // ============================================
+  // GET /groups/:groupId/records - 운동 기록 목록 조회
+  // ============================================
+  async getRecords(req, res) {
+    const groupId = parseInt(req.params.groupId);
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 10;
+    const order = req.query.order || "desc";
+    const orderBy = req.query.orderBy || "createdAt";
+    const search = req.query.search || "";
+
+    debugLog("운동 기록 목록 조회:", { groupId, page, limit, order, orderBy });
+
+    try {
+      // WHERE 조건
+      const where = {
+        groupId,
+        ...(search && {
+          author: {
+            nickname: {
+              contains: search,
+              mode: "insensitive",
+            },
+          },
+        }),
+      };
+
+      // ORDER BY
+      const orderByField = { [orderBy]: order };
+
+      // 조회
+      const [records, total] = await Promise.all([
+        prisma.record.findMany({
+          where,
+          include: {
+            author: {
+              select: {
+                id: true,
+                nickname: true,
+              },
+            },
+          },
+          orderBy: orderByField,
+          skip: (page - 1) * limit,
+          take: limit,
+        }),
+        prisma.record.count({ where }),
+      ]);
+
+      debugLog(`운동 기록 ${records.length}개 조회 완료 (전체: ${total})`);
+
+      res.status(200).json({
+        message: "운동 기록 목록 조회 성공",
+        data: records,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+        },
+      });
+    } catch (error) {
+      debugError("운동 기록 목록 조회 실패:", error);
+      throw error;
+    }
+  }
+
+  // ============================================
+  // GET /groups/:groupId/records/:recordId - 운동 기록 상세 조회
+  // ============================================
+  async getRecordById(req, res) {
+    const groupId = parseInt(req.params.groupId);
+    const recordId = parseInt(req.params.recordId);
+
+    debugLog("운동 기록 상세 조회:", { groupId, recordId });
+
+    try {
+      const record = await prisma.record.findFirst({
+        where: {
+          id: recordId,
+          groupId, // 그룹 일치 확인
+        },
+        include: {
+          author: {
+            select: {
+              id: true,
+              nickname: true,
+            },
+          },
+        },
+      });
+
+      if (!record) {
+        throw new NotFoundError("운동 기록을 찾을 수 없습니다");
+      }
+
+      debugLog("운동 기록 상세 조회 완료:", record.id);
+
+      // API 명세에 맞는 응답 형식
+      res.status(200).json(record);
+    } catch (error) {
+      debugError("운동 기록 상세 조회 실패:", error);
+      throw error;
+    }
+  }
+}
+
+export default new RecordController();

--- a/src/routes/record-routes.js
+++ b/src/routes/record-routes.js
@@ -1,23 +1,20 @@
-import express from "express";
-import recordController from "../controllers/record-controller.js";
-import {
-  validateRecordCreate,
-  validateRecordQuery,
-} from "../validators/record-validator.js";
+import express from 'express';
+import recordController from '../controllers/record-controller.js';
+import { validateRecordCreate, validateRecordQuery } from '../validators/record-validator.js';
 
-const router = express.Router({ mergeParams: true });
+const router = express.Router({ mergeParams: true }); // mergeParams로 :groupId 사용 가능
 
 // ============================================
-// 운동 기록 API 라우터
+// 운동 기록 관련 라우트
 // ============================================
-
-// POST /groups/:groupId/records - 운동 기록 생성
-router.post("/", validateRecordCreate, recordController.createRecord);
 
 // GET /groups/:groupId/records - 운동 기록 목록 조회
-router.get("/", validateRecordQuery, recordController.getRecords);
+router.get('/', validateRecordQuery, recordController.getRecords);
+
+// POST /groups/:groupId/records - 운동 기록 생성
+router.post('/', validateRecordCreate, recordController.createRecord);
 
 // GET /groups/:groupId/records/:recordId - 운동 기록 상세 조회
-router.get("/:recordId", recordController.getRecordById);
+router.get('/:recordId', recordController.getRecordById);
 
 export default router;

--- a/src/routes/record-routes.js
+++ b/src/routes/record-routes.js
@@ -1,0 +1,23 @@
+import express from "express";
+import recordController from "../controllers/record-controller.js";
+import {
+  validateRecordCreate,
+  validateRecordQuery,
+} from "../validators/record-validator.js";
+
+const router = express.Router({ mergeParams: true });
+
+// ============================================
+// 운동 기록 API 라우터
+// ============================================
+
+// POST /groups/:groupId/records - 운동 기록 생성
+router.post("/", validateRecordCreate, recordController.createRecord);
+
+// GET /groups/:groupId/records - 운동 기록 목록 조회
+router.get("/", validateRecordQuery, recordController.getRecords);
+
+// GET /groups/:groupId/records/:recordId - 운동 기록 상세 조회
+router.get("/:recordId", recordController.getRecordById);
+
+export default router;

--- a/src/utils/image-utils.js
+++ b/src/utils/image-utils.js
@@ -1,0 +1,193 @@
+/**
+ * 이미지 URL 변환 유틸리티
+ *
+ * 호성님의 image-controller와 연계하여 이미지 경로를 처리합니다.
+ * - 저장 시: URL에서 "uploads/파일명.jpg" 추출
+ * - 조회 시: "uploads/파일명.jpg"를 전체 URL로 변환
+ *
+ * 사용하는 곳:
+ * - record (운동 기록 photos)
+ * - group (나중에 이미지 추가 시)
+ * - 기타 이미지를 사용하는 모든 기능에 적용 가능
+ */
+
+/**
+ * URL에서 경로 추출
+ *
+ * 팀원의 image-controller는 다음 형식으로 URL을 반환:
+ * - "http://localhost:3000/uploads/abc.jpg"
+ *
+ * DB에는 "uploads/abc.jpg" 형식으로 저장하여 BASE_URL 변경에 유연하게 대응
+ *
+ * @param {string} url - 전체 URL 또는 경로
+ * @returns {string|null} "uploads/파일명.jpg" 형식의 경로
+ *
+ * @example
+ * extractImagePath("http://localhost:3000/uploads/abc.jpg")
+ * // → "uploads/abc.jpg"
+ *
+ * extractImagePath("uploads/abc.jpg")
+ * // → "uploads/abc.jpg"
+ *
+ * extractImagePath("abc.jpg")
+ * // → "uploads/abc.jpg"
+ */
+export function extractImagePath(url) {
+  if (!url) return null;
+
+  // 이미 "uploads/"로 시작하면 그대로 반환
+  if (url.startsWith('uploads/')) {
+    return url;
+  }
+
+  // URL에서 "uploads/파일명" 부분 추출
+  // "http://localhost:3000/uploads/abc.jpg" → "uploads/abc.jpg"
+  const match = url.match(/uploads\/[^\/]+$/);
+  if (match) {
+    return match[0];
+  }
+
+  // 매칭 안 되면 파일명만 추출해서 uploads/ 추가
+  const filename = url.split('/').pop();
+  return `uploads/${filename}`;
+}
+
+/**
+ * 경로를 전체 URL로 변환
+ *
+ * DB에 저장된 "uploads/abc.jpg"를 환경에 맞는 전체 URL로 변환
+ *
+ * @param {string} path - DB에 저장된 경로
+ * @returns {string|null} 전체 URL
+ *
+ * @example
+ * // 개발 환경 (BASE_URL=http://localhost:3000)
+ * buildImageUrl("uploads/abc.jpg")
+ * // → "http://localhost:3000/uploads/abc.jpg"
+ *
+ * // 프로덕션 환경 (BASE_URL=https://api.example.com)
+ * buildImageUrl("uploads/abc.jpg")
+ * // → "https://api.example.com/uploads/abc.jpg"
+ */
+export function buildImageUrl(path) {
+  if (!path) return null;
+
+  // 이미 전체 URL이면 그대로 반환
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path;
+  }
+
+  // BASE_URL과 결합
+  const baseUrl = process.env.BASE_URL || '';
+  return `${baseUrl}/${path}`;
+}
+
+/**
+ * URL 배열을 경로 배열로 변환 (저장용)
+ *
+ * 클라이언트가 보낸 URL 배열을 DB 저장용 경로 배열로 변환
+ *
+ * @param {string[]} urls - URL 배열
+ * @returns {string[]} 경로 배열
+ *
+ * @example
+ * convertUrlsToPaths([
+ *   "http://localhost:3000/uploads/abc.jpg",
+ *   "http://localhost:3000/uploads/def.jpg"
+ * ])
+ * // → ["uploads/abc.jpg", "uploads/def.jpg"]
+ */
+export function convertUrlsToPaths(urls) {
+  if (!urls || !Array.isArray(urls)) return [];
+  return urls.map((url) => extractImagePath(url)).filter((path) => path !== null);
+}
+
+/**
+ * 경로 배열을 URL 배열로 변환 (조회용)
+ *
+ * DB의 경로 배열을 클라이언트 응답용 URL 배열로 변환
+ *
+ * @param {string[]} paths - 경로 배열
+ * @returns {string[]} URL 배열
+ *
+ * @example
+ * convertPathsToUrls(["uploads/abc.jpg", "uploads/def.jpg"])
+ * // → [
+ * //   "http://localhost:3000/uploads/abc.jpg",
+ * //   "http://localhost:3000/uploads/def.jpg"
+ * // ]
+ */
+export function convertPathsToUrls(paths) {
+  if (!paths || !Array.isArray(paths)) return [];
+  return paths.map((path) => buildImageUrl(path)).filter((url) => url !== null);
+}
+
+/**
+ * 단일 객체의 이미지 필드를 URL로 변환
+ *
+ * DB에서 조회한 객체의 이미지 필드들을 전체 URL로 변환
+ *
+ * @param {Object} obj - DB에서 조회한 객체
+ * @param {string[]} imageFields - 변환할 이미지 필드명 배열
+ * @returns {Object} 이미지가 URL로 변환된 객체
+ *
+ * @example
+ * const record = {
+ *   id: 1,
+ *   photos: ["uploads/abc.jpg"],
+ *   thumbnail: "uploads/thumb.jpg"
+ * };
+ *
+ * convertImageFieldsToUrls(record, ['photos', 'thumbnail'])
+ * // → {
+ * //   id: 1,
+ * //   photos: ["http://localhost:3000/uploads/abc.jpg"],
+ * //   thumbnail: "http://localhost:3000/uploads/thumb.jpg"
+ * // }
+ */
+export function convertImageFieldsToUrls(obj, imageFields = ['photos']) {
+  if (!obj) return obj;
+
+  const converted = { ...obj };
+
+  for (const field of imageFields) {
+    if (converted[field]) {
+      // 배열인 경우
+      if (Array.isArray(converted[field])) {
+        converted[field] = convertPathsToUrls(converted[field]);
+      }
+      // 단일 값인 경우
+      else if (typeof converted[field] === 'string') {
+        converted[field] = buildImageUrl(converted[field]);
+      }
+    }
+  }
+
+  return converted;
+}
+
+/**
+ * 배열 객체들의 이미지 필드를 URL로 변환
+ *
+ * DB에서 조회한 객체 배열의 이미지 필드들을 전체 URL로 변환
+ *
+ * @param {Object[]} array - DB에서 조회한 객체 배열
+ * @param {string[]} imageFields - 변환할 이미지 필드명 배열
+ * @returns {Object[]} 이미지가 URL로 변환된 객체 배열
+ *
+ * @example
+ * const records = [
+ *   { id: 1, photos: ["uploads/abc.jpg"] },
+ *   { id: 2, photos: ["uploads/def.jpg"] }
+ * ];
+ *
+ * convertArrayImageFieldsToUrls(records, ['photos'])
+ * // → [
+ * //   { id: 1, photos: ["http://localhost:3000/uploads/abc.jpg"] },
+ * //   { id: 2, photos: ["http://localhost:3000/uploads/def.jpg"] }
+ * // ]
+ */
+export function convertArrayImageFieldsToUrls(array, imageFields = ['photos']) {
+  if (!array || !Array.isArray(array)) return array;
+  return array.map((obj) => convertImageFieldsToUrls(obj, imageFields));
+}

--- a/src/validators/record-validator.js
+++ b/src/validators/record-validator.js
@@ -1,67 +1,60 @@
-import { ValidationError } from "../middlewares/error-handler.js";
+import { ValidationError } from '../middlewares/error-handler.js';
 
 // ============================================
 // 운동 기록 생성 검증
 // ============================================
 
 export function validateRecordCreate(req, res, next) {
-  const {
-    exerciseType,
-    description,
-    time,
-    distance,
-    photos,
-    authorNickname,
-    authorPassword,
-  } = req.body;
+  const { exerciseType, description, time, distance, photos, authorNickname, authorPassword } =
+    req.body;
 
   // 필수 필드 검증
   if (!exerciseType) {
-    return next(new ValidationError("운동 종류는 필수입니다"));
+    return next(new ValidationError('exerciseType', '운동 종류는 필수입니다'));
   }
 
-  if (!["run", "bike", "swim"].includes(exerciseType)) {
+  if (!['run', 'bike', 'swim'].includes(exerciseType)) {
     return next(
-      new ValidationError("운동 종류는 달리기, 자전거, 수영 중 하나여야 합니다")
+      new ValidationError('exerciseType', '운동 종류는 달리기, 자전거, 수영 중 하나여야 합니다'),
     );
   }
 
   if (!description) {
-    return next(new ValidationError("설명은 필수입니다"));
+    return next(new ValidationError('description', '설명은 필수입니다'));
   }
 
   if (time === undefined || time === null) {
-    return next(new ValidationError("운동 시간은 필수입니다"));
+    return next(new ValidationError('time', '운동 시간은 필수입니다'));
   }
 
-  if (typeof time !== "number" || time <= 0) {
-    return next(new ValidationError("운동 시간은 0보다 큰 숫자여야 합니다"));
+  if (typeof time !== 'number' || time <= 0) {
+    return next(new ValidationError('time', '운동 시간은 0보다 큰 숫자여야 합니다'));
   }
 
   if (distance === undefined || distance === null) {
-    return next(new ValidationError("거리는 필수입니다"));
+    return next(new ValidationError('distance', '거리는 필수입니다'));
   }
 
-  if (typeof distance !== "number" || distance < 0) {
-    return next(new ValidationError("거리는 0 이상의 숫자여야 합니다"));
+  if (typeof distance !== 'number' || distance < 0) {
+    return next(new ValidationError('distance', '거리는 0 이상의 숫자여야 합니다'));
   }
 
   if (!authorNickname) {
-    return next(new ValidationError("닉네임은 필수입니다"));
+    return next(new ValidationError('authorNickname', '닉네임은 필수입니다'));
   }
 
   if (!authorPassword) {
-    return next(new ValidationError("비밀번호는 필수입니다"));
+    return next(new ValidationError('authorPassword', '비밀번호는 필수입니다'));
   }
 
   // photos 검증 (선택)
   if (photos) {
     if (!Array.isArray(photos)) {
-      return next(new ValidationError("사진은 배열 형태여야 합니다"));
+      return next(new ValidationError('photos', '사진은 배열 형태여야 합니다'));
     }
 
     if (photos.length > 3) {
-      return next(new ValidationError("사진은 최대 3장까지 업로드 가능합니다"));
+      return next(new ValidationError('photos', '사진은 최대 3장까지 업로드 가능합니다'));
     }
   }
 
@@ -77,24 +70,22 @@ export function validateRecordQuery(req, res, next) {
 
   // page 검증
   if (page && (isNaN(page) || parseInt(page) < 1)) {
-    return next(new ValidationError("page는 1 이상의 숫자여야 합니다"));
+    return next(new ValidationError('page', 'page는 1 이상의 숫자여야 합니다'));
   }
 
   // limit 검증
   if (limit && (isNaN(limit) || parseInt(limit) < 1)) {
-    return next(new ValidationError("limit는 1 이상의 숫자여야 합니다"));
+    return next(new ValidationError('limit', 'limit는 1 이상의 숫자여야 합니다'));
   }
 
   // order 검증
-  if (order && !["asc", "desc"].includes(order)) {
-    return next(new ValidationError("order는 asc 또는 desc여야 합니다"));
+  if (order && !['asc', 'desc'].includes(order)) {
+    return next(new ValidationError('order', 'order는 asc 또는 desc여야 합니다'));
   }
 
   // orderBy 검증
-  if (orderBy && !["createdAt", "time"].includes(orderBy)) {
-    return next(
-      new ValidationError("orderBy는 createdAt 또는 time이어야 합니다")
-    );
+  if (orderBy && !['createdAt', 'time'].includes(orderBy)) {
+    return next(new ValidationError('orderBy', 'orderBy는 createdAt 또는 time이어야 합니다'));
   }
 
   next();

--- a/src/validators/record-validator.js
+++ b/src/validators/record-validator.js
@@ -1,0 +1,101 @@
+import { ValidationError } from "../middlewares/error-handler.js";
+
+// ============================================
+// 운동 기록 생성 검증
+// ============================================
+
+export function validateRecordCreate(req, res, next) {
+  const {
+    exerciseType,
+    description,
+    time,
+    distance,
+    photos,
+    authorNickname,
+    authorPassword,
+  } = req.body;
+
+  // 필수 필드 검증
+  if (!exerciseType) {
+    return next(new ValidationError("운동 종류는 필수입니다"));
+  }
+
+  if (!["run", "bike", "swim"].includes(exerciseType)) {
+    return next(
+      new ValidationError("운동 종류는 달리기, 자전거, 수영 중 하나여야 합니다")
+    );
+  }
+
+  if (!description) {
+    return next(new ValidationError("설명은 필수입니다"));
+  }
+
+  if (time === undefined || time === null) {
+    return next(new ValidationError("운동 시간은 필수입니다"));
+  }
+
+  if (typeof time !== "number" || time <= 0) {
+    return next(new ValidationError("운동 시간은 0보다 큰 숫자여야 합니다"));
+  }
+
+  if (distance === undefined || distance === null) {
+    return next(new ValidationError("거리는 필수입니다"));
+  }
+
+  if (typeof distance !== "number" || distance < 0) {
+    return next(new ValidationError("거리는 0 이상의 숫자여야 합니다"));
+  }
+
+  if (!authorNickname) {
+    return next(new ValidationError("닉네임은 필수입니다"));
+  }
+
+  if (!authorPassword) {
+    return next(new ValidationError("비밀번호는 필수입니다"));
+  }
+
+  // photos 검증 (선택)
+  if (photos) {
+    if (!Array.isArray(photos)) {
+      return next(new ValidationError("사진은 배열 형태여야 합니다"));
+    }
+
+    if (photos.length > 3) {
+      return next(new ValidationError("사진은 최대 3장까지 업로드 가능합니다"));
+    }
+  }
+
+  next();
+}
+
+// ============================================
+// 운동 기록 목록 조회 쿼리 검증
+// ============================================
+
+export function validateRecordQuery(req, res, next) {
+  const { page, limit, order, orderBy } = req.query;
+
+  // page 검증
+  if (page && (isNaN(page) || parseInt(page) < 1)) {
+    return next(new ValidationError("page는 1 이상의 숫자여야 합니다"));
+  }
+
+  // limit 검증
+  if (limit && (isNaN(limit) || parseInt(limit) < 1)) {
+    return next(new ValidationError("limit는 1 이상의 숫자여야 합니다"));
+  }
+
+  // order 검증
+  if (order && !["asc", "desc"].includes(order)) {
+    return next(new ValidationError("order는 asc 또는 desc여야 합니다"));
+  }
+
+  // orderBy 검증
+  if (orderBy && !["createdAt", "time"].includes(orderBy)) {
+    return next(
+      new ValidationError("orderBy는 createdAt 또는 time이어야 합니다")
+    );
+  }
+
+  next();
+}


### PR DESCRIPTION
## 🎯 목적
- 그룹 내 운동 기록을 관리하는 API 구현

### ✅ 구현 완료
- [x] 운동 기록 생성 API
- [x] 운동 기록 목록 조회 API (페이지네이션, 정렬, 검색)
- [x] 운동 기록 상세 조회 API
- [x] 이미지 업로드 통합 (호성님 기능)
- [x] 이미지 URL 유틸리티 (공통 모듈)

### 🚧 추후 작업
- [] 디스코드 웹훅 전송
- [] 그룹 배지 갱신

## 📝 주요 변경사항
### 1. 이미지 URL 유틸리티 (image-utils.js)
- URL ↔ 경로 변환 공통 함수
- BASE_URL 환경변수로 유연한 배포가능한 이미지 컨트롤러 활용

### 2. Record Controller
- 참여자 인증 (닉네임 + 비밀번호)
- 페이지네이션 및 정렬
- 통합 에러 처리

### 3. Validator
- 필수 필드 및 타입 검증
- Query 파라미터 검증


## 🧪 테스트
```bash# 기록 생성
POST /groups/:groupId/records

# 목록 조회
GET /groups/:groupId/records?page=1&limit=10

# 상세 조회
GET /groups/:groupId/records/:recordId
```

## 🔍 리뷰 요청
- 이미지 URL 처리 로직
- 에러 처리 일관성
- Validator 검증 규칙