### PR TITLE
[정동원] feat: 운동기록 webhook처리 구현

### DIFF
--- a/_project_guide/팀1_feature_반영가이드.md
+++ b/_project_guide/팀1_feature_반영가이드.md
@@ -18,7 +18,7 @@ node --version
 ## STEP1 : (git 작업) 현재 작업 저장
 
 ```
-# 현재 작업중인 브랜치에서 작업 내용 커밋 (예시 브랜치명:sanghwi-api)
+# 현재 작업중인 브랜치에서 작업 내용 커 밋 (예시 브랜치명:sanghwi-api)
 
 git add .
 git commit -m "wip: sanghwi api 작업 중"

--- a/_project_guide/팀1_feature_반영가이드.md
+++ b/_project_guide/팀1_feature_반영가이드.md
@@ -18,7 +18,7 @@ node --version
 ## STEP1 : (git 작업) 현재 작업 저장
 
 ```
-# 현재 작업중인 브랜치에서 작업 내용 커 밋 (예시 브랜치명:sanghwi-api)
+# 현재 작업중인 브랜치에서 작업 내용 커밋 (예시 브랜치명:sanghwi-api)
 
 git add .
 git commit -m "wip: sanghwi api 작업 중"

--- a/src/controllers/group-controller.js
+++ b/src/controllers/group-controller.js
@@ -1,46 +1,34 @@
-import {
-  NotFoundError,
-  UnauthorizedError,
-  ValidationError,
-} from "../middlewares/error-handler.js";
-import { debugError, debugLog } from "../utils/debug.js";
-import prisma from "../utils/prisma.js";
+import { NotFoundError, UnauthorizedError, ValidationError } from '../middlewares/error-handler.js';
+import { debugError, debugLog } from '../utils/debug.js';
+import prisma from '../utils/prisma.js';
 
 class GroupController {
   //group 데이터 목록 조회
   async getGroupList(req, res, next) {
     try {
       //목록 조회 쿼리 default값
-      const {
-        page = 1,
-        limit = 10,
-        order = "createdAt",
-        sort = "desc",
-        name,
-      } = req.query;
+      const { page = 1, limit = 10, order = 'createdAt', sort = 'desc', name } = req.query;
 
       //order 쿼리로 group데이터 출력 기준 및 순서 변경
-      if (sort !== "asc" && sort !== "desc") {
-        throw new ValidationError(
-          "sort는 반드시 [asc, desc] 중 하나여야 합니다."
-        );
+      if (sort !== 'asc' && sort !== 'desc') {
+        throw new ValidationError('sort는 반드시 [asc, desc] 중 하나여야 합니다.');
       }
 
       let orderBy;
 
       switch (order) {
-        case "participantCount":
+        case 'participantCount':
           orderBy = { participants: { _count: sort } };
           break;
-        case "likeCount":
+        case 'likeCount':
           orderBy = { likeCount: sort };
           break;
-        case "createdAt":
+        case 'createdAt':
           orderBy = { createdAt: sort };
           break;
         default:
           throw new ValidationError(
-            `order은 반드시 [createdAt, likeCount, participantCount] 중 하나여야 합니다.`
+            `order은 반드시 [createdAt, likeCount, participantCount] 중 하나여야 합니다.`,
           );
       }
 
@@ -54,7 +42,7 @@ class GroupController {
         where: {
           name: {
             contains: name,
-            mode: "insensitive",
+            mode: 'insensitive',
           },
         },
       });
@@ -64,7 +52,7 @@ class GroupController {
       //   throw new NotFoundError("group 목록을 찾을 수 없습니다.");
       // }
 
-      res.status(200).json({ message: "목록 생성 완료", data: groups });
+      res.status(200).json({ message: '목록 생성 완료', data: groups });
     } catch (err) {
       next(err);
     }
@@ -74,27 +62,27 @@ class GroupController {
   async createGroup(req, res, next) {
     try {
       if (!req.body.name) {
-        throw new ValidationError("그룹명은 필수입니다");
+        throw new ValidationError('그룹명은 필수입니다');
       }
 
       const goalRep = parseInt(req.body.goalRep);
       if (!Number.isInteger(req.body.goalRep) || goalRep <= 0) {
-        throw new ValidationError("목표 횟수는 0 이상의 수여야 합니다.");
+        throw new ValidationError('목표 횟수는 0 이상의 수여야 합니다.');
       }
 
       if (!req.body.ownerId) {
-        throw new ValidationError("소유자의 id가 없거나 인식되지 않았습니다.");
+        throw new ValidationError('소유자의 id가 없거나 인식되지 않았습니다.');
       }
 
       const group = await prisma.group.create({
         data: req.body,
       });
 
-      debugLog("group 생성 완료", group);
+      debugLog('group 생성 완료', group);
 
-      res.status(201).json({ message: "group 생성 완료", data: group });
+      res.status(201).json({ message: 'group 생성 완료', data: group });
     } catch (err) {
-      debugError("group 생성 실패", err);
+      debugError('group 생성 실패', err);
 
       next(err);
       /*
@@ -116,12 +104,12 @@ class GroupController {
       });
 
       if (!group) {
-        throw new NotFoundError("group ID가 존재하지 않습니다.");
+        throw new NotFoundError('group ID가 존재하지 않습니다.');
       }
 
-      res.status(200).json({ message: "group 상세 조회 완료", data: group });
+      res.status(200).json({ message: 'group 상세 조회 완료', data: group });
     } catch (err) {
-      debugError("group 호출 실패", err);
+      debugError('group 호출 실패', err);
       next(err);
     }
   }
@@ -143,25 +131,25 @@ class GroupController {
       });
 
       if (!group) {
-        throw new NotFoundError("group ID가 존재하지 않습니다.");
+        throw new NotFoundError('group ID가 존재하지 않습니다.');
       }
 
       if (!group.owner) {
-        throw new UnauthorizedError("group owner의 정보를 찾을 수 없습니다.");
+        throw new UnauthorizedError('group owner의 정보를 찾을 수 없습니다.');
       }
 
       const ownerPassword = group.owner.password;
       debugLog(ownerPassword);
 
       if (pw !== ownerPassword) {
-        throw new UnauthorizedError("group owner의 비밀번호가 틀렸습니다.");
+        throw new UnauthorizedError('group owner의 비밀번호가 틀렸습니다.');
       }
 
       await prisma.group.delete({
         where: { id: Number(id) },
       });
 
-      res.status(200).json({ message: "group이 성공적으로 삭제되었습니다." });
+      res.status(200).json({ message: 'group이 성공적으로 삭제되었습니다.' });
     } catch (err) {
       next(err);
     }
@@ -185,27 +173,27 @@ class GroupController {
       });
 
       if (!findGroup) {
-        throw new NotFoundError("group ID가 존재하지 않습니다.");
+        throw new NotFoundError('group ID가 존재하지 않습니다.');
       }
 
       if (!findGroup.owner) {
-        throw new UnauthorizedError("group owner의 정보를 찾을 수 없습니다.");
+        throw new UnauthorizedError('group owner의 정보를 찾을 수 없습니다.');
       }
 
       const ownerPassword = findGroup.owner.password;
       debugLog(ownerPassword);
 
       if (pw !== ownerPassword) {
-        throw new UnauthorizedError("group owner의 비밀번호가 틀렸습니다.");
+        throw new UnauthorizedError('group owner의 비밀번호가 틀렸습니다.');
       }
 
       if (!req.body.name) {
-        throw new ValidationError("그룹명은 필수입니다");
+        throw new ValidationError('그룹명은 필수입니다');
       }
 
       const goalRep = parseInt(req.body.goalRep);
       if (!Number.isInteger(req.body.goalRep) || goalRep < 0) {
-        throw new ValidationError("목표 횟수는 0 이상의 수여야 합니다.");
+        throw new ValidationError('목표 횟수는 0 이상의 수여야 합니다.');
       }
 
       const group = await prisma.group.update({
@@ -213,7 +201,7 @@ class GroupController {
         data: updateData,
       });
 
-      res.status(200).json({ message: "group 수정 완료", data: group });
+      res.status(200).json({ message: 'group 수정 완료', data: group });
     } catch (err) {
       next(err);
     }

--- a/src/controllers/record-controller.js
+++ b/src/controllers/record-controller.js
@@ -6,6 +6,7 @@ import {
   convertImageFieldsToUrls,
   convertArrayImageFieldsToUrls,
 } from '../utils/image-utils.js';
+import { sendChangeRecordMsg } from '../utils/discord-msg-utils.js';
 
 /**
  * 운동 기록 컨트롤러
@@ -89,8 +90,10 @@ class RecordController {
         where: { id: groupId },
       });
 
+      //주의. seed data에는 webhook URL이 null로 되어있음
+      //테스트를 하려면 sendChangeRecordMsg 함수를 if문 밖으로 내놓고, 함수내의 주석대로 코드 일부 활성화 및 비활성화 필요
       if (group?.discordWebhookUrl) {
-        // TODO: 디스코드 웹훅 전송 로직 구현 (추후 구현)
+        sendChangeRecordMsg(group, record);
         debugLog('디스코드 웹훅 URL:', group.discordWebhookUrl);
       }
 

--- a/src/controllers/record-controller.js
+++ b/src/controllers/record-controller.js
@@ -85,17 +85,20 @@ class RecordController {
       debugLog('운동 기록 생성 완료:', record.id);
       debugLog('DB에 저장된 photos:', record.photos);
 
-      // 4. 디스코드 웹훅 전송 (비동기, 실패해도 무시)
+      // 4. 디스코드 웹훅 전송
+      //utils폴더 내 discord-msg-utils.js의 함수에서 webhook 처리
+      sendChangeRecordMsg(record);
+
+      //아래 부분은 group에 webHookURL이 들어갈 때 활성화 및 수정
+      /*
       const group = await prisma.group.findUnique({
         where: { id: groupId },
       });
 
-      //주의. seed data에는 webhook URL이 null로 되어있음
-      //테스트를 하려면 sendChangeRecordMsg 함수를 if문 밖으로 내놓고, 함수내의 주석대로 코드 일부 활성화 및 비활성화 필요
       if (group?.discordWebhookUrl) {
-        sendChangeRecordMsg(group, record);
         debugLog('디스코드 웹훅 URL:', group.discordWebhookUrl);
       }
+      */
 
       // 5. 배지 업데이트 (추후 구현)
       // await updateGroupBadges(groupId);

--- a/src/utils/discord-msg-utils.js
+++ b/src/utils/discord-msg-utils.js
@@ -1,26 +1,32 @@
+import { debugError } from './debug.js';
+
 export async function sendChangeRecordMsg(record) {
-  const discordURL =
-    'https://discord.com/api/webhooks/1435533418145255516/2nIZI1jChcPZHGuAMbZOZ2DK4lJ5EwyF1-YHZMD7hM62yAai0L39obMkae_y8fj425uD';
+  try {
+    const discordURL =
+      'https://discord.com/api/webhooks/1435533418145255516/2nIZI1jChcPZHGuAMbZOZ2DK4lJ5EwyF1-YHZMD7hM62yAai0L39obMkae_y8fj425uD';
 
-  const embeds = [
-    {
-      title: `[${record.author.nickname}]님의 운동 기록`,
-      fields: [
-        { name: '운동 시간 : ', value: record.time },
-        { name: '운동 타입 : ', value: record.exerciseType },
-      ],
-    },
-  ];
+    const embeds = [
+      {
+        title: `[${record.author.nickname}]님의 운동 기록`,
+        fields: [
+          { name: '운동 시간 : ', value: record.time },
+          { name: '운동 타입 : ', value: record.exerciseType },
+        ],
+      },
+    ];
 
-  let response;
-  response = fetch(discordURL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      username: '운동기록알림',
-      embeds: embeds,
-    }),
-  });
+    let response;
+    response = await fetch(discordURL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username: '운동기록알림',
+        embeds: embeds,
+      }),
+    });
+  } catch (err) {
+    debugError('webhook 처리에 실패했습니다.', err.message);
+  }
 }

--- a/src/utils/discord-msg-utils.js
+++ b/src/utils/discord-msg-utils.js
@@ -1,45 +1,28 @@
-import { NotFoundError } from '../middlewares/error-handler.js';
 import { debugError } from './debug.js';
 
-export async function sendChangeRecordMsg(group, record, next) {
-  try {
-    //기본 seed data에는  webhookURL이 null 처리 되어있음
-    //기본 seed가지고 테스트 하려면 아래 코드 활성화 및 아래 코드 비활성화
+export async function sendChangeRecordMsg(record) {
+  const discordURL =
+    'https://discord.com/api/webhooks/1435533418145255516/2nIZI1jChcPZHGuAMbZOZ2DK4lJ5EwyF1-YHZMD7hM62yAai0L39obMkae_y8fj425uD';
 
-    // const discordURL =
-    //   'https://discord.com/api/webhooks/1435533418145255516/2nIZI1jChcPZHGuAMbZOZ2DK4lJ5EwyF1-YHZMD7hM62yAai0L39obMkae_y8fj425uD';
+  const embeds = [
+    {
+      title: `[${record.author.nickname}]님의 운동 기록`,
+      fields: [
+        { name: '운동 시간 : ', value: record.time },
+        { name: '운동 타입 : ', value: record.exerciseType },
+      ],
+    },
+  ];
 
-    //테스트 하려면 이 사이의 코드 비활성화
-    const discordURL = group.discordWebhookUrl;
-
-    if (!group.discordWebhookUrl) {
-      throw new NotFoundError('Discord webhook용 URL이 존재하지 않습니다.');
-    }
-    //테스트 하려면 이 사이의 코드 비활성화
-
-    debugError('그룹 URL확인됨', discordURL);
-
-    const embeds = [
-      {
-        title: `[${record.author.nickname}]님의 운동 기록`,
-        fields: [
-          { name: '운동 시간 : ', value: record.time },
-          { name: '운동 타입 : ', value: record.exerciseType },
-        ],
-      },
-    ];
-
-    const response = await fetch(discordURL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        username: '운동기록알림',
-        embeds: embeds,
-      }),
-    });
-  } catch (err) {
-    next(err);
-  }
+  let response;
+  response = fetch(discordURL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      username: '운동기록알림',
+      embeds: embeds,
+    }),
+  });
 }

--- a/src/utils/discord-msg-utils.js
+++ b/src/utils/discord-msg-utils.js
@@ -1,0 +1,45 @@
+import { NotFoundError } from '../middlewares/error-handler.js';
+import { debugError } from './debug.js';
+
+export async function sendChangeRecordMsg(group, record, next) {
+  try {
+    //기본 seed data에는  webhookURL이 null 처리 되어있음
+    //기본 seed가지고 테스트 하려면 아래 코드 활성화 및 아래 코드 비활성화
+
+    // const discordURL =
+    //   'https://discord.com/api/webhooks/1435533418145255516/2nIZI1jChcPZHGuAMbZOZ2DK4lJ5EwyF1-YHZMD7hM62yAai0L39obMkae_y8fj425uD';
+
+    //테스트 하려면 이 사이의 코드 비활성화
+    const discordURL = group.discordWebhookUrl;
+
+    if (!group.discordWebhookUrl) {
+      throw new NotFoundError('Discord webhook용 URL이 존재하지 않습니다.');
+    }
+    //테스트 하려면 이 사이의 코드 비활성화
+
+    debugError('그룹 URL확인됨', discordURL);
+
+    const embeds = [
+      {
+        title: `[${record.author.nickname}]님의 운동 기록`,
+        fields: [
+          { name: '운동 시간 : ', value: record.time },
+          { name: '운동 타입 : ', value: record.exerciseType },
+        ],
+      },
+    ];
+
+    const response = await fetch(discordURL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username: '운동기록알림',
+        embeds: embeds,
+      }),
+    });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/utils/discord-msg-utils.js
+++ b/src/utils/discord-msg-utils.js
@@ -1,5 +1,3 @@
-import { debugError } from './debug.js';
-
 export async function sendChangeRecordMsg(record) {
   const discordURL =
     'https://discord.com/api/webhooks/1435533418145255516/2nIZI1jChcPZHGuAMbZOZ2DK4lJ5EwyF1-YHZMD7hM62yAai0L39obMkae_y8fj425uD';


### PR DESCRIPTION
# 운동기록 webhook 구현 완료

#### 작업 내용 
- record-api에서 운동기록 생성을 하면 discord 1팀-service에서 기록이 나오게 함
- utils 폴더에 discord-msg-utils.js로 함수를 분리


#### 기타 참고사항
- seed data에서 discordWebhookURL이 null로 되어있어, 생성이 잘되는지 테스트 하고 싶으면, discord-msg-utils함수에서 url을 group에서 받아오는 것이 아닌 링크 자체를 받아야지 테스트가 가능해집니다. record-api와 discord-msg-utils 파일에 주석으로 어디 부분을 변경해야하는지 작성해놨으니, 참고 바랍니다.


코드 내에 문제가 있거나, 폴더 구조의 문제, 변수명 문제 등이 존재한다면 말씀주세요. 바로 반영하도록 하겠습니다.



